### PR TITLE
bug: old version numpy.float type deprecated for numpy >= 1.24

### DIFF
--- a/moverscore_v2.py
+++ b/moverscore_v2.py
@@ -159,8 +159,8 @@ def word_mover_score(refs, hyps, idf_dict_ref, idf_dict_hyp, stop_words=[], n_gr
         distance_matrix = batched_cdist_l2(raw, raw).double().cpu().numpy()
                 
         for i in range(batch_size):  
-            c1 = np.zeros(raw.shape[1], dtype=np.float)
-            c2 = np.zeros(raw.shape[1], dtype=np.float)
+            c1 = np.zeros(raw.shape[1], dtype=float)
+            c2 = np.zeros(raw.shape[1], dtype=float)
             c1[:len(ref_idf[i])] = ref_idf[i]
             c2[len(ref_idf[i]):] = hyp_idf[i]
             
@@ -169,7 +169,7 @@ def word_mover_score(refs, hyps, idf_dict_ref, idf_dict_hyp, stop_words=[], n_gr
             
             dst = distance_matrix[i]
             _, flow = emd_with_flow(c1, c2, dst)
-            flow = np.array(flow, dtype=np.float32)
+            flow = np.array(flow, dtype=float)
             score = 1./(1. + np.sum(flow * dst))#1 - np.sum(flow * dst)
             preds.append(score)
 
@@ -198,8 +198,8 @@ def plot_example(is_flow, reference, translation, device='cuda:0'):
 
     
     i = 0
-    c1 = np.zeros(raw.shape[1], dtype=np.float)
-    c2 = np.zeros(raw.shape[1], dtype=np.float)
+    c1 = np.zeros(raw.shape[1], dtype=float)
+    c2 = np.zeros(raw.shape[1], dtype=float)
     c1[:len(ref_idf[i])] = ref_idf[i]
     c2[len(ref_idf[i]):] = hyp_idf[i]
     
@@ -210,7 +210,7 @@ def plot_example(is_flow, reference, translation, device='cuda:0'):
 
     if is_flow:        
         _, flow = emd_with_flow(c1, c2, dst)
-        new_flow = np.array(flow, dtype=np.float32)    
+        new_flow = np.array(flow, dtype=float)    
         res = new_flow[:len(ref_tokens[i]), len(ref_idf[i]): (len(ref_idf[i])+len(hyp_tokens[i]))]
     else:    
         res = 1./(1. + dst[:len(ref_tokens[i]), len(ref_idf[i]): (len(ref_idf[i])+len(hyp_tokens[i]))]) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch>=1.0.0
 pyemd==0.5.1
 pytorch-transformers>=1.1.0
+numpy>=1.24


### PR DESCRIPTION
## Context
- Issues: Moverscore demo code fails to run because numpy.float64 or numpy.float32 types are deprecated for the **mainstream** numpy version >= `1.24`. The error is as below for any numpy version >= 1.24.


- Code to run
```
refs = ['The dog bit the man.', 'The dog had bit the man.']
sys = 'The dog bit the man.'
mover = sentence_score(sys, refs)
print(mover)
```

- Exception raised:
![image](https://github.com/AIPHES/emnlp19-moverscore/assets/31399290/8b847446-5c4f-4d81-8103-6cd1aa6c45e1)


## Changes
Fixes: I replaced all occurrences with **python float** type as suggested in this [answer](https://stackoverflow.com/questions/74844262/how-can-i-solve-error-module-numpy-has-no-attribute-float-in-python) and tested it with Moverscore -- it works. The numpy new version >= `1.24` should have compatibility for other functions in the older version. 
